### PR TITLE
chore: ignores `yarn.lock`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /coverage
 /node_modules
 /vendor
+yarn.lock


### PR DESCRIPTION
This pull request makes git ignore `yarn.lock`, just for helping people using yarn.