### PR TITLE
fix: return type expander when type doesn't exist

### DIFF
--- a/source/Expander/ReturnTypeExpander.php
+++ b/source/Expander/ReturnTypeExpander.php
@@ -14,9 +14,10 @@ class ReturnTypeExpander extends AbstractExpander
 {
     public function expand(Ast $ast, Engine $engine): TokenStream
     {
-        $tokens = [":"];
+        $tokens = [];
 
         if (!empty(($branch = $this->find($ast, "nullableType")))) {
+            $tokens[] = [":"];
             $tokens[] = (string) (new NullableTypeExpander())->expand(
                 new Ast("", ["nullableType" => $branch]),
                 $engine

--- a/tests/Expander/ReturnTypeExpanderTest.php
+++ b/tests/Expander/ReturnTypeExpanderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pre\Standard\Tests\Expander;
+
+use PHPUnit\Framework\TestCase;
+use Pre\Standard\Tests\HasExpand;
+use Yay\Engine;
+
+class ReturnTypeExpanderTest extends TestCase
+{
+    use HasExpand;
+
+    protected $macro = '
+        $(macro) {
+            $(\Pre\Standard\Parser\returnType())
+        } >> {
+            $$(\Pre\Standard\Expander\returnType($(returnType)))
+        }
+    ';
+
+    public function test_return_type_extension_with_type()
+    {
+        $expected = <<<CODE
+function fnWithReturnType(): string
+{
+    // noop
+}
+CODE;
+
+        $actual = $this->expand($expected);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test_return_type_extension_without_type()
+    {
+        $expected = <<<CODE
+function fnWithReturnType()
+{
+    // noop
+}
+CODE;
+
+        $actual = $this->expand($expected);
+
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
This pull requests fixes the return type expander macro when the type doesn't exist.

Will unblock this: https://github.com/preprocess/plus/pull/12.